### PR TITLE
Fix recursion bug in nuker and add unit test

### DIFF
--- a/account_nuker.py
+++ b/account_nuker.py
@@ -193,7 +193,7 @@ async def close_all_dms(token):
                                     retry_after = await delete_response.json()  
                                     logging.warning(f"Rate limited. Retrying after {retry_after['retry_after']} seconds...")
                                     await asyncio.sleep(retry_after['retry_after'])
-                                    await close_all_dms(session, base_url, headers, token) 
+                                    await close_all_dms(token)
                                 else:
                                     logging.error(f"Failed to delete DM: {channel_id} (status: {delete_response.status})")
                         except Exception as e:
@@ -230,7 +230,7 @@ async def remove_all_friends(token):
                                         retry_after = await delete_response.json()  
                                         logging.warning(f"Rate limited. Retrying after {retry_after['retry_after']} seconds...")
                                         await asyncio.sleep(retry_after['retry_after'])
-                                        await remove_all_friends(session, base_url, headers, token) 
+                                        await remove_all_friends(token)
                                     else:
                                         logging.error(f"Failed to remove friend: {friend['user']['username']} (status: {delete_response.status})")
                         except Exception as e:

--- a/tests/test_nuker.py
+++ b/tests/test_nuker.py
@@ -1,0 +1,56 @@
+import asyncio
+from unittest.mock import AsyncMock
+import pytest
+
+import sys
+import os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+import account_nuker
+
+class DummyResponse:
+    def __init__(self, status, data=None):
+        self.status = status
+        self._data = data or {}
+
+    async def json(self):
+        return self._data
+
+class DummyRequest:
+    def __init__(self, response):
+        self._response = response
+
+    async def __aenter__(self):
+        return self._response
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+class DummySession:
+    def __init__(self):
+        self.delete_calls = 0
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    def get(self, url, headers=None):
+        return DummyRequest(DummyResponse(200, [{"id": "1"}]))
+
+    def delete(self, url, headers=None):
+        self.delete_calls += 1
+        if self.delete_calls == 1:
+            return DummyRequest(DummyResponse(420, {"retry_after": 0}))
+        return DummyRequest(DummyResponse(204))
+
+@pytest.mark.asyncio
+async def test_close_all_dms_handles_rate_limit(mocker):
+    session = DummySession()
+    mocker.patch('aiohttp.ClientSession', return_value=session)
+    mocker.patch('asyncio.sleep', AsyncMock())
+    mocker.patch('account_nuker.tqdm', lambda it, **k: it)
+
+    await account_nuker.close_all_dms("token")
+    assert session.delete_calls >= 2
+


### PR DESCRIPTION
## Summary
- fix recursive calls in `close_all_dms` and `remove_all_friends`
- add tests for DM deletion rate limit handling